### PR TITLE
Jest.config.ts created for jest to ignore e2e dir

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,10 +1,7 @@
 import type { Config } from 'jest';
 
 const config: Config = {
-    testPathIgnorePatterns: [
-        '/e2e/',
-        '/home.spec.ts/',
-    ],
+	testPathIgnorePatterns: ['/e2e/', '/home.spec.ts/'],
 };
 
 export default config;


### PR DESCRIPTION
Jest configuration file created and configured it to ignore e2e directory where test is supposed to be done by playwright.