### PR TITLE
add transaction to db and fix some budget creation problems on web

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -85,10 +85,6 @@ export default function RootLayout() {
 								name="(tabs)"
 								options={{ headerShown: false }}
 							/>
-							<Stack.Screen
-								name="modal"
-								options={{ presentation: 'modal' }}
-							/>
 						</Stack>
 					</SafeAreaProvider>
 				</Theme>

--- a/app/add_transaction2.tsx
+++ b/app/add_transaction2.tsx
@@ -18,6 +18,8 @@ import type {
 	RealTransaction,
 	TransactionOccurrence,
 } from '@/src/dataModel';
+import { isDbReal } from '@/src/db/client';
+import { useAddRealTransaction } from '@/src/finance/hook/useAddRealTransaction';
 import { useCategoryStore } from '@/src/store/categoryStore';
 import usePlannedTransactionsStore from '@/src/store/usePlannedTransactionsStore';
 import useRealTransactionsStore from '@/src/store/useRealTransactionsStore';
@@ -26,6 +28,7 @@ import RealTransactionModal from '../src/components/RealTransactionModal';
 export default function AddTransaction() {
 	const [popupVisible, setPopupVisible] = useState(false);
 	const addTransaction = useRealTransactionsStore((state) => state.add);
+	const addRealTransactionToDb = useAddRealTransaction();
 	const [transactionType, setTransactionType] = useState<
 		'income' | 'expense'
 	>('income');
@@ -47,6 +50,7 @@ export default function AddTransaction() {
 				amount?: number;
 				date?: Date;
 				category?: number;
+				plannedTransactionId?: number | null;
 		  }
 		| undefined
 	>(undefined);
@@ -128,6 +132,8 @@ export default function AddTransaction() {
 				amount: Number(allocationAmount),
 				date: new Date(selectedPlannedTxn.date),
 				category: selectedPlannedTxn.categoryId,
+				plannedTransactionId:
+					selectedPlannedTxn.plannedTransaction?.id ?? null,
 			});
 			setTransactionType(selectedPlannedTxn.type);
 
@@ -140,15 +146,32 @@ export default function AddTransaction() {
 		}
 	};
 
-	function addItem(newItem: RealTransaction) {
-		addTransaction({
+	async function addItem(newItem: RealTransaction) {
+		const transactionToInsert: RealTransaction = {
 			...newItem,
 			type: transactionType,
 			categoryId: newItem.categoryId ?? 0,
-		});
-		setPopupVisible(false);
-		setPrefillData(undefined); // Clear prefill data
-		setShowSuccess(true);
+			plannedTransactionId:
+				newItem.plannedTransactionId ??
+				prefillData?.plannedTransactionId ??
+				null,
+		};
+
+		try {
+			if (isDbReal) {
+				const insertedTransaction =
+					await addRealTransactionToDb(transactionToInsert);
+				addTransaction(insertedTransaction);
+			} else {
+				addTransaction(transactionToInsert);
+			}
+
+			setPopupVisible(false);
+			setPrefillData(undefined);
+			setShowSuccess(true);
+		} catch (error) {
+			console.error('Failed to save real transaction:', error);
+		}
 	}
 
 	return (
@@ -163,7 +186,9 @@ export default function AddTransaction() {
 					transparent={true}
 				>
 					<RealTransactionModal
-						onAdd={(item) => addItem(item)}
+						onAdd={(item) => {
+							void addItem(item);
+						}}
 						onClose={() => {
 							setPopupVisible(false);
 							setPrefillData(undefined);

--- a/src/components/RealTransactionModal.tsx
+++ b/src/components/RealTransactionModal.tsx
@@ -25,6 +25,7 @@ type RealTransactionModalProps = {
 		amount?: number;
 		date?: Date;
 		category?: number;
+		plannedTransactionId?: number | null;
 	};
 };
 
@@ -67,7 +68,8 @@ const RealTransactionModal = ({
 			!name.trim() ||
 			Number.isNaN(numAmount) ||
 			numAmount <= 0 ||
-			!date
+			!date ||
+			selectedCategory === null
 		) {
 			return;
 		}
@@ -79,11 +81,16 @@ const RealTransactionModal = ({
 			date,
 			type: transactionType,
 			categoryId: selectedCategory ?? 0,
+			plannedTransactionId: prefillData?.plannedTransactionId ?? null,
 		});
 	};
 
 	const isDisabled =
-		!name.trim() || !amount || Number.parseFloat(amount) <= 0 || !date;
+		!name.trim() ||
+		!amount ||
+		Number.parseFloat(amount) <= 0 ||
+		!date ||
+		selectedCategory === null;
 
 	const handleAddCategory = async () => {
 		if (!newCategoryName.trim()) return;

--- a/src/finance/hook/useAddBalanceReconciliation.ts
+++ b/src/finance/hook/useAddBalanceReconciliation.ts
@@ -10,10 +10,8 @@ export function useAddBalanceReconciliation() {
 
 	const setInitialBalance = useCallback(
 		async (amount: number) => {
-			// Save to database
 			const newReconciliation = await insertBalanceReconciliation(amount);
 
-			// Tell versioning system to invalidate cache
 			onBalanceReconciliationCreated(newReconciliation);
 		},
 		[onBalanceReconciliationCreated],

--- a/src/finance/hook/useAddRealTransaction.ts
+++ b/src/finance/hook/useAddRealTransaction.ts
@@ -1,0 +1,32 @@
+import { useCallback } from 'react';
+import type { Persisted, RealTransaction } from '@/src/dataModel';
+import { insertRealTransaction } from '../query/realTransactionMutations';
+import { useBalanceVersioning } from '../versioning/balanceVersioning';
+import { useTransactionOccurrenceVersioning } from '../versioning/transactionOccurrenceVersioning';
+
+export function useAddRealTransaction() {
+	const onBalanceRealTransactionCreated = useBalanceVersioning(
+		(state) => state.onRealTransactionCreated,
+	);
+	const onOccurrenceRealTransactionCreated =
+		useTransactionOccurrenceVersioning(
+			(state) => state.onRealTransactionCreated,
+		);
+
+	const addRealTransaction = useCallback(
+		async (
+			transaction: RealTransaction,
+		): Promise<Persisted<RealTransaction>> => {
+			const insertedTransaction =
+				await insertRealTransaction(transaction);
+
+			onBalanceRealTransactionCreated(insertedTransaction);
+			onOccurrenceRealTransactionCreated(insertedTransaction);
+
+			return insertedTransaction;
+		},
+		[onBalanceRealTransactionCreated, onOccurrenceRealTransactionCreated],
+	);
+
+	return addRealTransaction;
+}

--- a/src/finance/query/balanceReconciliationMutations.ts
+++ b/src/finance/query/balanceReconciliationMutations.ts
@@ -1,12 +1,19 @@
 import { and, eq, gte, lte } from 'drizzle-orm';
 import { DEFAULT_ACCOUNT_ID } from '@/src/dataModel';
-import { db } from '@/src/db/client';
+import { db, isDbReal } from '@/src/db/client';
 import * as schema from '@/src/db/schema';
+import useBalanceReconciliationStore from '@/src/store/useBalanceReconciliationStore';
 
 export async function insertBalanceReconciliation(
 	amount: number,
 	date: Date = new Date(),
 ) {
+	if (!isDbReal) {
+		return useBalanceReconciliationStore
+			.getState()
+			.upsertForDay(amount, date, DEFAULT_ACCOUNT_ID);
+	}
+
 	const startOfDay = new Date(date);
 	startOfDay.setHours(0, 0, 0, 0);
 	const endOfDay = new Date(date);

--- a/src/finance/query/balanceReconciliationQueries.ts
+++ b/src/finance/query/balanceReconciliationQueries.ts
@@ -1,8 +1,9 @@
 import { endOfMonth } from 'date-fns/endOfMonth';
 import { lte } from 'drizzle-orm';
 import type { BalanceReconciliation, Persisted } from '@/src/dataModel';
-import { db } from '@/src/db/client';
+import { db, isDbReal } from '@/src/db/client';
 import * as schema from '@/src/db/schema';
+import useBalanceReconciliationStore from '@/src/store/useBalanceReconciliationStore';
 
 /**
  * Retrieves all balance reconciliations that occur before or within the given month
@@ -14,6 +15,12 @@ export async function fetchBalanceReconciliationsBeforeOrIn(
 	year: number,
 	month: number,
 ): Promise<Persisted<BalanceReconciliation>[]> {
+	if (!isDbReal) {
+		return useBalanceReconciliationStore
+			.getState()
+			.getBeforeOrIn(year, month);
+	}
+
 	const data = await db
 		.select()
 		.from(schema.balanceReconciliations)

--- a/src/finance/query/realTransactionMutations.ts
+++ b/src/finance/query/realTransactionMutations.ts
@@ -1,0 +1,17 @@
+import type { Persisted, RealTransaction } from '@/src/dataModel';
+import { db } from '@/src/db/client';
+import * as schema from '@/src/db/schema';
+
+export async function insertRealTransaction(
+	transaction: RealTransaction,
+): Promise<Persisted<RealTransaction>> {
+	const [insertedRealTransaction] = await db
+		.insert(schema.realTransactions)
+		.values({
+			...transaction,
+			plannedTransactionId: transaction.plannedTransactionId ?? null,
+		})
+		.returning();
+
+	return insertedRealTransaction;
+}

--- a/src/store/useBalanceReconciliationStore.ts
+++ b/src/store/useBalanceReconciliationStore.ts
@@ -1,0 +1,95 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+import type { BalanceReconciliation, Persisted } from '../dataModel';
+
+interface BalanceReconciliationState {
+	reconciliations: Persisted<BalanceReconciliation>[];
+	nextId: number;
+	upsertForDay: (
+		amount: number,
+		date: Date,
+		accountId: number,
+	) => Persisted<BalanceReconciliation>;
+	getBeforeOrIn: (
+		year: number,
+		month: number,
+	) => Persisted<BalanceReconciliation>[];
+}
+
+const useBalanceReconciliationStore = create<BalanceReconciliationState>()(
+	persist(
+		(set, get) => ({
+			reconciliations: [],
+			nextId: 1,
+			upsertForDay: (amount: number, date: Date, accountId: number) => {
+				const startOfDay = new Date(date);
+				startOfDay.setHours(0, 0, 0, 0);
+				const endOfDay = new Date(date);
+				endOfDay.setHours(23, 59, 59, 999);
+
+				const state = get();
+				const existingRecord = state.reconciliations.find(
+					(record) =>
+						record.date >= startOfDay && record.date <= endOfDay,
+				);
+
+				if (existingRecord) {
+					const updatedRecord: Persisted<BalanceReconciliation> = {
+						...existingRecord,
+						amount,
+						date,
+					};
+
+					set((prev) => ({
+						...prev,
+						reconciliations: prev.reconciliations.map((record) =>
+							record.id === existingRecord.id
+								? updatedRecord
+								: record,
+						),
+					}));
+
+					return updatedRecord;
+				}
+
+				const insertedRecord: Persisted<BalanceReconciliation> = {
+					id: state.nextId,
+					accountId,
+					amount,
+					date,
+				};
+
+				set((prev) => ({
+					...prev,
+					reconciliations: [...prev.reconciliations, insertedRecord],
+					nextId: prev.nextId + 1,
+				}));
+
+				return insertedRecord;
+			},
+			getBeforeOrIn: (year: number, month: number) => {
+				const end = new Date(year, month + 1, 0, 23, 59, 59, 999);
+				return get()
+					.reconciliations.filter((record) => record.date <= end)
+					.sort((a, b) => a.date.getTime() - b.date.getTime());
+			},
+		}),
+		{
+			name: 'balance-reconciliation-storage',
+			storage: createJSONStorage(() => AsyncStorage),
+			onRehydrateStorage: () => (state) => {
+				if (state) {
+					state.reconciliations = state.reconciliations.map(
+						(record) => ({
+							...record,
+							date: new Date(record.date),
+						}),
+					);
+				}
+			},
+		},
+	),
+);
+
+export default useBalanceReconciliationStore;


### PR DESCRIPTION
Closes #93 

Support for database and local storage. 

* Added a new Zustand-based persistent store (`useBalanceReconciliationStore`) for balance reconciliations, allowing local storage and retrieval when not connected to a real database.
* Updated `insertBalanceReconciliation` and `fetchBalanceReconciliationsBeforeOrIn` to use the local store when `isDbReal` is false, enabling seamless switching between local and remote data sources.

**Transaction Handling Enhancements:**

* Added `useAddRealTransaction` hook and `insertRealTransaction` function to insert real transactions into the database and update versioning systems, with support for the `plannedTransactionId` field
* Refactored `add_transaction2.tsx` to use the new transaction insertion logic, handle errors, and ensure the `plannedTransactionId` is set correctly when adding transactions.

**UI and Validation Improvements:**

* Improved validation in `RealTransactionModal` to require category selection and propagate the `plannedTransactionId` when adding a transaction.

**Other Minor Changes:**

* Removed the unused "modal" screen from the navigation stack in `RootLayout`.
* Cleaned up comments and improved clarity in the balance reconciliation hook.