### PR TITLE
add grouping calculations and hone the UI

### DIFF
--- a/app/(tabs)/budget/_layout.tsx
+++ b/app/(tabs)/budget/_layout.tsx
@@ -9,6 +9,7 @@ export default function SummaryStackLayout() {
 			screenOptions={{
 				headerShadowVisible: false,
 				headerStyle: { backgroundColor: '#f2f2f2' },
+				headerLargeTitle: false,
 			}}
 		>
 			<Stack.Screen name="index" options={{ headerShown: false }} />
@@ -16,7 +17,6 @@ export default function SummaryStackLayout() {
 				name="[year]"
 				options={({ route }) => ({
 					title: `${t('Year')} ${(route.params as { year?: string })?.year}`,
-					headerLargeTitle: false,
 				})}
 			/>
 		</Stack>

--- a/app/(tabs)/budget/detail/[id].tsx
+++ b/app/(tabs)/budget/detail/[id].tsx
@@ -8,6 +8,7 @@ import { usePlannedTransactions } from '@/src/finance/hook/usePlannedTransaction
 import { getTransactionOccurrenceCount } from '@/src/finance/logic/util';
 
 type ProcessedItem = {
+	id: number;
 	name: string;
 	count: number;
 	totalAmount: number;
@@ -68,6 +69,7 @@ export default function BudgetDetailedMonthScreen() {
 				const catIdStr = String(evt.categoryId);
 
 				const processedItem: ProcessedItem = {
+					id: evt.id,
 					name: evt.name,
 					count: count,
 					totalAmount: totalAmount,
@@ -196,37 +198,30 @@ export default function BudgetDetailedMonthScreen() {
 													</SizableText>
 												</XStack>
 
-												{cat.items.map(
-													(item, index) => (
-														<XStack
-															// biome-ignore lint/suspicious/noArrayIndexKey: <No unique id>
-															key={`expense-${item.name}-${index}`}
-															justifyContent="space-between"
-															paddingLeft="$3"
-															marginTop="$1"
+												{cat.items.map((item) => (
+													<XStack
+														key={`expense-${item.id}`}
+														justifyContent="space-between"
+														paddingLeft="$3"
+														marginTop="$1"
+													>
+														<SizableText
+															size="$3"
+															color="$color11"
 														>
-															<SizableText
-																size="$3"
-																color="$color11"
-															>
-																{item.count > 1
-																	? `${item.name} (x${item.count})`
-																	: item.name}
-															</SizableText>
-															<SizableText
-																size="$3"
-																color="$color11"
-															>
-																{Math.abs(
-																	item.totalAmount,
-																).toFixed(
-																	2,
-																)}{' '}
-																€
-															</SizableText>
-														</XStack>
-													),
-												)}
+															{item.name}
+														</SizableText>
+														<SizableText
+															size="$3"
+															color="$color11"
+														>
+															{Math.abs(
+																item.totalAmount,
+															).toFixed(2)}{' '}
+															€
+														</SizableText>
+													</XStack>
+												))}
 											</YStack>
 										))}
 									</YStack>
@@ -299,37 +294,30 @@ export default function BudgetDetailedMonthScreen() {
 													</SizableText>
 												</XStack>
 
-												{cat.items.map(
-													(item, index) => (
-														<XStack
-															// biome-ignore lint/suspicious/noArrayIndexKey: <No unique id>
-															key={`expense-${item.name}-${index}`}
-															justifyContent="space-between"
-															paddingLeft="$3"
-															marginTop="$1"
+												{cat.items.map((item) => (
+													<XStack
+														key={`expense-${item.id}`}
+														justifyContent="space-between"
+														paddingLeft="$3"
+														marginTop="$1"
+													>
+														<SizableText
+															size="$3"
+															color="$color11"
 														>
-															<SizableText
-																size="$3"
-																color="$color11"
-															>
-																{item.count > 1
-																	? `${item.name} (x${item.count})`
-																	: item.name}
-															</SizableText>
-															<SizableText
-																size="$3"
-																color="$color11"
-															>
-																{Math.abs(
-																	item.totalAmount,
-																).toFixed(
-																	2,
-																)}{' '}
-																€
-															</SizableText>
-														</XStack>
-													),
-												)}
+															{item.name}
+														</SizableText>
+														<SizableText
+															size="$3"
+															color="$color11"
+														>
+															{Math.abs(
+																item.totalAmount,
+															).toFixed(2)}{' '}
+															€
+														</SizableText>
+													</XStack>
+												))}
 											</YStack>
 										))}
 									</YStack>

--- a/app/(tabs)/budget/index.tsx
+++ b/app/(tabs)/budget/index.tsx
@@ -18,9 +18,6 @@ export default function YearsScreen() {
 		<YStack flex={1} backgroundColor="$background">
 			<ScrollView>
 				<YStack padding="$4" gap="$3">
-					<SizableText size="$5" color="$color10" marginBottom="$2">
-						{t('Choose a year')}
-					</SizableText>
 					<Button
 						backgroundColor="$primary200"
 						borderRadius={40}

--- a/app/(tabs)/summary/index.tsx
+++ b/app/(tabs)/summary/index.tsx
@@ -18,9 +18,6 @@ export default function YearsScreen() {
 		<YStack flex={1} backgroundColor="$background">
 			<ScrollView>
 				<YStack padding="$4" gap="$3">
-					<SizableText size="$5" color="$color10" marginBottom="$2">
-						{t('Choose a year')}
-					</SizableText>
 					{availableYears.map((year) => (
 						<Card
 							key={year}

--- a/app/(tabs)/summary/index.tsx
+++ b/app/(tabs)/summary/index.tsx
@@ -11,7 +11,7 @@ export default function YearsScreen() {
 
 	const availableYears = useMemo(() => {
 		const currentYear = new Date().getFullYear();
-		return Array.from({ length: 6 }, (_, i) => String(currentYear + i));
+		return Array.from({ length: 6 }, (_, i) => String(currentYear - i));
 	}, []);
 
 	return (

--- a/src/finance/logic/util.ts
+++ b/src/finance/logic/util.ts
@@ -139,10 +139,10 @@ export function getTransactionOccurrenceCount(
 	targetYear: number,
 	targetMonth: number,
 ): number {
-	if (!txn.startDate) return 1;
+	if (!txn.startDate) return 0;
 
 	const start = safeParseDate(txn.startDate);
-	if (Number.isNaN(start.getTime())) return 1;
+	if (Number.isNaN(start.getTime())) return 0;
 
 	const startYear = start.getFullYear();
 	const startMonth = start.getMonth();
@@ -172,7 +172,7 @@ export function getTransactionOccurrenceCount(
 		return targetYear === startYear && targetMonth === startMonth ? 1 : 0;
 	}
 
-	const base = txn.recurrenceBase || 'month';
+	const base = txn.recurrenceBase;
 	const interval = txn.recurrenceInterval || 1;
 
 	if (base === 'month') {

--- a/src/finance/logic/util.ts
+++ b/src/finance/logic/util.ts
@@ -168,6 +168,10 @@ export function getTransactionOccurrenceCount(
 		}
 	}
 
+	if (txn.recurrenceBase == null) {
+		return targetYear === startYear && targetMonth === startMonth ? 1 : 0;
+	}
+
 	const base = txn.recurrenceBase || 'month';
 	const interval = txn.recurrenceInterval || 1;
 
@@ -184,12 +188,16 @@ export function getTransactionOccurrenceCount(
 	}
 
 	if (base === 'week') {
+		if (txn.type === 'income' && interval < 4) {
+			return 365 / (7 * interval) / 12;
+		}
+
 		let count = 0;
 		const d = new Date(targetYear, targetMonth, 1);
 		while (d.getMonth() === targetMonth) {
 			const daysDiff = getDaysDiff(start, d);
 			if (daysDiff >= 0 && daysDiff % 7 === 0) {
-				const weeksSinceStart = daysDiff / 7;
+				const weeksSinceStart = Math.floor(daysDiff / 7);
 				if (weeksSinceStart % interval === 0) {
 					count++;
 				}
@@ -200,6 +208,10 @@ export function getTransactionOccurrenceCount(
 	}
 
 	if (base === 'day') {
+		if (txn.type === 'income' && interval <= 30) {
+			return 365 / (1 * interval) / 12;
+		}
+
 		let count = 0;
 		const d = new Date(targetYear, targetMonth, 1);
 		while (d.getMonth() === targetMonth) {
@@ -212,5 +224,5 @@ export function getTransactionOccurrenceCount(
 		return count;
 	}
 
-	return 1;
+	return 0;
 }

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -370,8 +370,9 @@ i18next
 				'Confirm': 'Vahvista',
 				'Update balance': 'Muokkaa saldoa',
 
-				// SUMMARY
-				'Choose a year': 'Valitse vuosi',
+				// BUDGET & SUMMARY
+
+				'Edit Budget': 'Muokkaa Budjettia',
 				'Planned': 'Suunniteltu',
 				'No expenses this month': 'Ei menoja tässä kuussa',
 				'No income this month': 'Ei tuloja tässä kuussa',


### PR DESCRIPTION
-Header expansion bug only happening on screen lock now, so that is something. Can not find a fix for it as of now.

-Updated budget calculations to correctly distribute incomes from events occurring more than once a month.

-Fixed one time planned transactions with no recurrenceBase from occurring monthly (oops!)

-Used previously missed ID of planned transaction to avoid having to use lintignore.

-Default transactions with no start or end date to once a month.

-Removed unnecessary 'Choose a year' texts from summary and budget screens.

-Added translation for edit budget button.