### PR TITLE
Feature/reimplement real transaction logic

### DIFF
--- a/app/(tabs)/funds.tsx
+++ b/app/(tabs)/funds.tsx
@@ -1,4 +1,3 @@
-import { useRouter } from 'expo-router';
 import { useState } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { YStack } from 'tamagui';
@@ -7,8 +6,6 @@ import DailyBalanceView from '@/src/components/DailyBalanceView';
 
 export default function Funds() {
 	const [selectedDate, setselectedDate] = useState(new Date());
-
-	const router = useRouter();
 
 	return (
 		<SafeAreaView style={{ flex: 1 }} edges={['left', 'right', 'bottom']}>
@@ -21,9 +18,6 @@ export default function Funds() {
 				<DailyBalanceView
 					onDateChange={setselectedDate}
 					selectedDate={selectedDate}
-					onAddPress={() => {
-						router.push('/add_transaction2');
-					}}
 				/>
 			</YStack>
 		</SafeAreaView>

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -193,28 +193,6 @@ export default function Landing() {
 									</YStack>
 								</YStack>
 								<FixBalanceModal />
-								{/* Buttons */}
-								<YStack f={1} ai="center" mt="3%">
-									<Button
-										backgroundColor="$primary200"
-										onPress={() =>
-											router.push('/add_transaction2')
-										}
-										minWidth={'85%'}
-										height={70}
-										borderRadius={40}
-									>
-										<Text
-											color={'$white'}
-											fontWeight={'700'}
-											fontSize={'$4'}
-											numberOfLines={1}
-											adjustsFontSizeToFit
-										>
-											{t('ADD INCOME/EXPENSE')}
-										</Text>
-									</Button>
-								</YStack>
 							</YStack>
 						)}
 

--- a/src/components/DailyBalanceView.tsx
+++ b/src/components/DailyBalanceView.tsx
@@ -1,14 +1,17 @@
 import { ChevronLeft, ChevronRight } from '@tamagui/lucide-icons';
 import { addMonths, subMonths } from 'date-fns';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Modal } from 'react-native';
 import { Button, ScrollView, Text, XStack, YStack } from 'tamagui';
+import { useAddRealTransaction } from '@/src/finance/hook/useAddRealTransaction';
 import { useOccurrencesAndBalances } from '@/src/finance/hook/useOccurrencesAndBalances';
 import { useUsableFunds } from '@/src/finance/hook/useUsableFunds';
+import { useCategoryStore } from '@/src/store/categoryStore';
 import { useTimeframeStore } from '@/src/store/useTimeframeStore';
 import { LOCALE } from '../constants/index';
 import type {
+	Category,
 	Persisted,
 	RealTransaction,
 	TransactionOccurrence,
@@ -17,13 +20,13 @@ import { formatCurrency } from '../utils/budgetUtils';
 import DailyEventList from './DailyEventList';
 import EditTransactionModal from './EditTransactionModal';
 import { MultiPlatformDatePicker } from './MultiPlatformDatePicker';
+import PlannedTransactionConfirmModal from './PlannedTransactionConfirmModal';
+import RealTransactionModal from './RealTransactionModal';
 import StyledCard from './styledCard';
 
 interface DailyBalanceViewProps {
 	selectedDate: Date;
 	onDateChange: (date: Date) => void;
-	onAddPress?: () => void;
-	onEditPress?: (txn: TransactionOccurrence) => void;
 }
 
 // Helper to format date as "dd.mm.yyyy"
@@ -34,16 +37,69 @@ const formatDate = (date: Date) => {
 export default function DailyBalanceView({
 	selectedDate,
 	onDateChange,
-	onAddPress,
 }: DailyBalanceViewProps) {
 	const { t } = useTranslation();
 
 	const [editingTransaction, setEditingTransaction] =
 		useState<Persisted<RealTransaction> | null>(null);
+	const [addModalVisible, setAddModalVisible] = useState(false);
+	const [addTransactionType, setAddTransactionType] = useState<
+		'income' | 'expense'
+	>('expense');
+	const [confirmingPlannedTxn, setConfirmingPlannedTxn] =
+		useState<TransactionOccurrence | null>(null);
+
+	const storeCategories = useCategoryStore();
+	const [categories, setCategories] = useState<Persisted<Category>[]>([]);
+	useEffect(() => {
+		setCategories(storeCategories.categories);
+	}, [storeCategories.categories]);
+
+	const addCategory = useCategoryStore((state) => state.addCategory);
+	const addRealTransactionToDb = useAddRealTransaction();
+
+	const dynamicCategories = categories.map((cat) => ({
+		key: cat.id,
+		label: cat.name,
+		type: cat.type,
+	}));
 
 	const handleEditPress = (txn: TransactionOccurrence) => {
 		if (txn.realTransaction) {
 			setEditingTransaction(txn.realTransaction);
+		}
+	};
+
+	const handleEditPlannedPress = (txn: TransactionOccurrence) => {
+		setConfirmingPlannedTxn(txn);
+	};
+
+	const handleOpenAddModal = (type: 'income' | 'expense') => {
+		setAddTransactionType(type);
+		setAddModalVisible(true);
+	};
+
+	const handleAddTransaction = async (item: RealTransaction) => {
+		try {
+			await addRealTransactionToDb(item);
+			setAddModalVisible(false);
+		} catch (error) {
+			console.error('Failed to save real transaction:', error);
+		}
+	};
+
+	const handleAddCategory = async (categoryName: string) => {
+		if (!categoryName.trim()) return;
+		try {
+			await addCategory({
+				name: categoryName,
+				type: addTransactionType,
+				color: '#000000',
+				icon: 'circle',
+			});
+		} catch (error) {
+			console.error('Failed to add category:', error);
+			throw error;
 		}
 	};
 
@@ -192,34 +248,56 @@ export default function DailyBalanceView({
 					</YStack>
 				</XStack>
 
-				{/* Add Button */}
-				<Button
-					backgroundColor="$primary100"
-					borderRadius="$4"
-					paddingHorizontal="$6"
-					paddingVertical="$2"
-					height="wrap-content"
-					onPress={onAddPress}
-					pressStyle={{ backgroundColor: '$primary200' }}
-					marginVertical={10}
-				>
-					<Text
-						color="$white"
-						fontWeight="500"
-						fontSize="$3"
-						numberOfLines={1}
-						adjustsFontSizeToFit
+				{/* Add Buttons */}
+				<XStack gap={8} marginVertical={10}>
+					<Button
+						backgroundColor="$primary100"
+						borderRadius="$4"
+						paddingHorizontal="$4"
+						paddingVertical="$2"
+						height="wrap-content"
+						flex={1}
+						onPress={() => handleOpenAddModal('income')}
+						pressStyle={{ backgroundColor: '$primary200' }}
 					>
-						{t('ADD INCOME/EXPENSE')}
-					</Text>
-				</Button>
+						<Text
+							color="$white"
+							fontWeight="500"
+							fontSize="$3"
+							numberOfLines={1}
+							adjustsFontSizeToFit
+						>
+							{t('Add income short')}
+						</Text>
+					</Button>
+					<Button
+						backgroundColor="$primary100"
+						borderRadius="$4"
+						paddingHorizontal="$4"
+						paddingVertical="$2"
+						height="wrap-content"
+						flex={1}
+						onPress={() => handleOpenAddModal('expense')}
+						pressStyle={{ backgroundColor: '$primary200' }}
+					>
+						<Text
+							color="$white"
+							fontWeight="500"
+							fontSize="$3"
+							numberOfLines={1}
+							adjustsFontSizeToFit
+						>
+							{t('Add expense short')}
+						</Text>
+					</Button>
+				</XStack>
 				<Text color="$black" fontSize="$2" fontWeight="600">
 					{t('Usable funds timeframe')}:{' '}
 					{`${formatDate(selectedDate)} - ${formatDate(currentTimeframeEnd)}`}
 				</Text>
 			</StyledCard>
 
-			{/* Edit transaction modal */}
+			{/* Edit real transaction modal */}
 			<Modal
 				visible={editingTransaction !== null}
 				onRequestClose={() => setEditingTransaction(null)}
@@ -229,6 +307,41 @@ export default function DailyBalanceView({
 					<EditTransactionModal
 						transaction={editingTransaction}
 						onClose={() => setEditingTransaction(null)}
+					/>
+				)}
+			</Modal>
+
+			{/* Add new real transaction modal */}
+			<Modal
+				visible={addModalVisible}
+				onRequestClose={() => setAddModalVisible(false)}
+				transparent
+			>
+				<RealTransactionModal
+					onAdd={(item) => {
+						void handleAddTransaction({
+							...item,
+							type: addTransactionType,
+						});
+					}}
+					onClose={() => setAddModalVisible(false)}
+					transactionType={addTransactionType}
+					categories={dynamicCategories}
+					onAddCategory={handleAddCategory}
+				/>
+			</Modal>
+
+			{/* Confirm / edit planned transaction modal */}
+			<Modal
+				visible={confirmingPlannedTxn !== null}
+				onRequestClose={() => setConfirmingPlannedTxn(null)}
+				transparent
+			>
+				{confirmingPlannedTxn && (
+					<PlannedTransactionConfirmModal
+						occurrence={confirmingPlannedTxn}
+						onClose={() => setConfirmingPlannedTxn(null)}
+						onConfirmed={() => setConfirmingPlannedTxn(null)}
 					/>
 				)}
 			</Modal>
@@ -260,6 +373,7 @@ export default function DailyBalanceView({
 							selectedDate={selectedDate}
 							formatCurrency={formatCurrency}
 							onEditPress={handleEditPress}
+							onEditPlannedPress={handleEditPlannedPress}
 							key={month.monthKey}
 						/>
 					))}

--- a/src/components/DailyEventList.tsx
+++ b/src/components/DailyEventList.tsx
@@ -8,6 +8,7 @@ interface Props {
 	monthKey: string;
 	selectedDate: Date;
 	onEditPress?: (txn: TransactionOccurrence) => void;
+	onEditPlannedPress?: (txn: TransactionOccurrence) => void;
 	formatCurrency: (value: number, hideSign?: boolean) => string;
 }
 
@@ -16,6 +17,7 @@ const DailyEventList: React.FC<Props> = ({
 	monthKey,
 	selectedDate,
 	onEditPress,
+	onEditPlannedPress,
 	formatCurrency,
 }) => {
 	const { t } = useTranslation();
@@ -158,6 +160,7 @@ const DailyEventList: React.FC<Props> = ({
 							selectedDate.toDateString()
 						}
 						onEditPress={onEditPress}
+						onEditPlannedPress={onEditPlannedPress}
 						formatCurrency={formatCurrency}
 						key={`${monthKey}-${dTxns[0].date.getDate()}`}
 					></DailyEventListItem>

--- a/src/components/DailyEventListItem.tsx
+++ b/src/components/DailyEventListItem.tsx
@@ -11,6 +11,7 @@ interface Props {
 	sum: number;
 	isSelected: boolean;
 	onEditPress?: (txn: TransactionOccurrence) => void;
+	onEditPlannedPress?: (txn: TransactionOccurrence) => void;
 	formatCurrency: (value: number, hideSign?: boolean) => string;
 }
 
@@ -21,6 +22,7 @@ const DailyEventListItem: React.FC<Props> = ({
 	sum,
 	isSelected,
 	onEditPress,
+	onEditPlannedPress,
 	formatCurrency,
 }) => {
 	const [isOpen, setOpen] = useState(isSelected);
@@ -99,7 +101,7 @@ const DailyEventListItem: React.FC<Props> = ({
 										{txn.type === 'income' ? '+' : '-'}
 										{formatCurrency(Number(txn.amount))}
 									</Text>
-									{/* Edit button only for real (DB-persisted) transactions */}
+									{/* Edit button for real (DB-persisted) transactions */}
 									{onEditPress && txn.realTransaction && (
 										<Button
 											size="$buttons.sm"
@@ -109,6 +111,20 @@ const DailyEventListItem: React.FC<Props> = ({
 											onPress={() => onEditPress(txn)}
 										/>
 									)}
+									{/* Confirm/edit button for planned transactions without a real transaction */}
+									{onEditPlannedPress &&
+										txn.plannedTransaction &&
+										!txn.realTransaction && (
+											<Button
+												size="$buttons.sm"
+												circular
+												backgroundColor="transparent"
+												icon={Pencil}
+												onPress={() =>
+													onEditPlannedPress(txn)
+												}
+											/>
+										)}
 								</XStack>
 							);
 						})

--- a/src/components/DailyEventListItem.tsx
+++ b/src/components/DailyEventListItem.tsx
@@ -74,99 +74,105 @@ const DailyEventListItem: React.FC<Props> = ({
 				</XStack>
 				{isOpen &&
 					(dTxns[0].name !== '' ? (
-						dTxns.map((txn, index) => {
-							const itemKey =
-								txn.realTransaction?.id != null
-									? `r-${txn.realTransaction.id}`
-									: txn.plannedTransaction?.id != null
-										? `p-${txn.plannedTransaction.id}-${txn.date.getTime()}`
-										: `f-${txn.date.getTime()}-${txn.name}-${txn.amount}-${index}`;
+						(() => {
+							const realTxns = dTxns.filter(
+								(txn) =>
+									txn.realTransaction != null ||
+									txn.plannedTransaction == null,
+							);
+							const plannedTxns = dTxns.filter(
+								(txn) =>
+									txn.plannedTransaction != null &&
+									txn.realTransaction == null,
+							);
 
-							const isUnconfirmedPlanned =
-								!!txn.plannedTransaction && !txn.realTransaction;
+							const renderRow = (
+								txn: TransactionOccurrence,
+								index: number,
+							) => {
+								const itemKey =
+									txn.realTransaction?.id != null
+										? `r-${txn.realTransaction.id}`
+										: txn.plannedTransaction?.id != null
+											? `p-${txn.plannedTransaction.id}-${txn.date.getTime()}`
+											: `f-${txn.date.getTime()}-${txn.name}-${txn.amount}-${index}`;
 
-							return (
-								<XStack
-									gap={10}
-									backgroundColor="transparent"
-									alignItems="center"
-									justifyContent="flex-end"
-									key={itemKey}
-									maxWidth={'90%'}
-									opacity={isUnconfirmedPlanned ? 0.65 : 1}
-								>
-									<YStack flex={1} gap={2}>
+								return (
+									<XStack
+										gap={10}
+										backgroundColor="transparent"
+										alignItems="center"
+										justifyContent="flex-end"
+										key={itemKey}
+										maxWidth={'90%'}
+									>
 										<Text
+											flex={1}
 											fontWeight="400"
 											textAlign="left"
 											fontSize="$body"
-											color={
-												isUnconfirmedPlanned
-													? '$gray600'
-													: '$color'
-											}
-											fontStyle={
-												isUnconfirmedPlanned
-													? 'italic'
-													: 'normal'
-											}
 										>
 											{txn.name}
 										</Text>
-										{/* Badge: unconfirmed planned */}
-										{isUnconfirmedPlanned && (
-											<Text
-												fontSize={10}
-												color="$gray500"
-												borderWidth={1}
-												borderColor="$gray400"
-												borderRadius={4}
-												paddingHorizontal={4}
-												paddingVertical={1}
-												alignSelf="flex-start"
-											>
-												{t('Budgeted badge')}
-											</Text>
-										)}
-									</YStack>
-									<Text
-										fontSize="$body"
-										fontWeight="400"
-										color={
-											isUnconfirmedPlanned
-												? '$gray600'
-												: '$color'
-										}
-									>
-										{txn.type === 'income' ? '+' : '-'}
-										{formatCurrency(Number(txn.amount))}
-									</Text>
-									{/* Edit button for real (DB-persisted) transactions */}
-									{onEditPress && txn.realTransaction && (
-										<Button
-											size="$buttons.sm"
-											circular
-											backgroundColor="transparent"
-											icon={Pencil}
-											onPress={() => onEditPress(txn)}
-										/>
-									)}
-									{/* Confirm/edit button for planned transactions without a real transaction */}
-									{onEditPlannedPress &&
-										isUnconfirmedPlanned && (
+										<Text fontSize="$body" fontWeight="400">
+											{txn.type === 'income' ? '+' : '-'}
+											{formatCurrency(Number(txn.amount))}
+										</Text>
+										{onEditPress && txn.realTransaction && (
 											<Button
 												size="$buttons.sm"
 												circular
 												backgroundColor="transparent"
 												icon={Pencil}
-												onPress={() =>
-													onEditPlannedPress(txn)
-												}
+												onPress={() => onEditPress(txn)}
 											/>
 										)}
-								</XStack>
+										{onEditPlannedPress &&
+											txn.plannedTransaction &&
+											!txn.realTransaction && (
+												<Button
+													size="$buttons.sm"
+													circular
+													backgroundColor="transparent"
+													icon={Pencil}
+													onPress={() =>
+														onEditPlannedPress(txn)
+													}
+												/>
+											)}
+									</XStack>
+								);
+							};
+
+							return (
+								<>
+									{realTxns.map((txn, i) =>
+										renderRow(txn, i),
+									)}
+									{plannedTxns.length > 0 && (
+										<>
+											<Text
+												fontSize="$2"
+												fontWeight="600"
+												color="$gray500"
+												marginTop={
+													realTxns.length > 0 ? 6 : 0
+												}
+												marginBottom={2}
+											>
+												{t('Planned section title')}
+											</Text>
+											{plannedTxns.map((txn, i) =>
+												renderRow(
+													txn,
+													realTxns.length + i,
+												),
+											)}
+										</>
+									)}
+								</>
 							);
-						})
+						})()
 					) : (
 						<Text
 							style={{ fontStyle: 'italic' }}

--- a/src/components/DailyEventListItem.tsx
+++ b/src/components/DailyEventListItem.tsx
@@ -1,5 +1,6 @@
 import { ChevronDown, ChevronUp, Pencil } from '@tamagui/lucide-icons';
 import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Button, Text, XStack, YStack } from 'tamagui';
 import { LOCALE } from '../constants/index';
 import type { TransactionOccurrence } from '../dataModel';
@@ -25,6 +26,7 @@ const DailyEventListItem: React.FC<Props> = ({
 	onEditPlannedPress,
 	formatCurrency,
 }) => {
+	const { t } = useTranslation();
 	const [isOpen, setOpen] = useState(isSelected);
 
 	// Automatically open list item when selected
@@ -80,6 +82,9 @@ const DailyEventListItem: React.FC<Props> = ({
 										? `p-${txn.plannedTransaction.id}-${txn.date.getTime()}`
 										: `f-${txn.date.getTime()}-${txn.name}-${txn.amount}-${index}`;
 
+							const isUnconfirmedPlanned =
+								!!txn.plannedTransaction && !txn.realTransaction;
+
 							return (
 								<XStack
 									gap={10}
@@ -88,16 +93,51 @@ const DailyEventListItem: React.FC<Props> = ({
 									justifyContent="flex-end"
 									key={itemKey}
 									maxWidth={'90%'}
+									opacity={isUnconfirmedPlanned ? 0.65 : 1}
 								>
+									<YStack flex={1} gap={2}>
+										<Text
+											fontWeight="400"
+											textAlign="left"
+											fontSize="$body"
+											color={
+												isUnconfirmedPlanned
+													? '$gray600'
+													: '$color'
+											}
+											fontStyle={
+												isUnconfirmedPlanned
+													? 'italic'
+													: 'normal'
+											}
+										>
+											{txn.name}
+										</Text>
+										{/* Badge: unconfirmed planned */}
+										{isUnconfirmedPlanned && (
+											<Text
+												fontSize={10}
+												color="$gray500"
+												borderWidth={1}
+												borderColor="$gray400"
+												borderRadius={4}
+												paddingHorizontal={4}
+												paddingVertical={1}
+												alignSelf="flex-start"
+											>
+												{t('Budgeted badge')}
+											</Text>
+										)}
+									</YStack>
 									<Text
-										flex={1}
-										fontWeight="400"
-										textAlign="left"
 										fontSize="$body"
+										fontWeight="400"
+										color={
+											isUnconfirmedPlanned
+												? '$gray600'
+												: '$color'
+										}
 									>
-										{txn.name}
-									</Text>
-									<Text fontSize="$body" fontWeight="400">
 										{txn.type === 'income' ? '+' : '-'}
 										{formatCurrency(Number(txn.amount))}
 									</Text>
@@ -113,8 +153,7 @@ const DailyEventListItem: React.FC<Props> = ({
 									)}
 									{/* Confirm/edit button for planned transactions without a real transaction */}
 									{onEditPlannedPress &&
-										txn.plannedTransaction &&
-										!txn.realTransaction && (
+										isUnconfirmedPlanned && (
 											<Button
 												size="$buttons.sm"
 												circular

--- a/src/components/PlannedTransactionConfirmModal.tsx
+++ b/src/components/PlannedTransactionConfirmModal.tsx
@@ -1,0 +1,291 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { StyleSheet, View } from 'react-native';
+import {
+	Button,
+	Input,
+	ScrollView,
+	SizableText,
+	XStack,
+	YStack,
+} from 'tamagui';
+import {
+	DEFAULT_ACCOUNT_ID,
+	type Persisted,
+	type RealTransaction,
+	type TransactionOccurrence,
+} from '../dataModel';
+import { useAddRealTransaction } from '../finance/hook/useAddRealTransaction';
+import { useUpdateRealTransaction } from '../finance/hook/useUpdateRealTransaction';
+import { useCategoryStore } from '../store/categoryStore';
+import { MultiPlatformDatePicker } from './MultiPlatformDatePicker';
+
+type PlannedTransactionConfirmModalProps = {
+	occurrence: TransactionOccurrence;
+	onClose: () => void;
+	onConfirmed: () => void;
+};
+
+const PlannedTransactionConfirmModal = ({
+	occurrence,
+	onClose,
+	onConfirmed,
+}: PlannedTransactionConfirmModalProps) => {
+	const { t } = useTranslation();
+	const categories = useCategoryStore((state) => state.categories);
+	const addRealTransaction = useAddRealTransaction();
+	const updateRealTransaction = useUpdateRealTransaction();
+
+	const [name, setName] = useState(occurrence.name);
+	const [amount, setAmount] = useState(
+		(occurrence.realTransaction?.amount ?? occurrence.amount).toString(),
+	);
+	const [date, setDate] = useState<Date>(new Date(occurrence.date));
+	const [selectedCategory, setSelectedCategory] = useState<number>(
+		occurrence.realTransaction?.categoryId ?? occurrence.categoryId,
+	);
+	const [saving, setSaving] = useState(false);
+	const [feedbackMessage, setFeedbackMessage] = useState<string | null>(null);
+
+	const filteredCategories = useMemo(
+		() => categories.filter((cat) => cat.type === occurrence.type),
+		[categories, occurrence.type],
+	);
+
+	useEffect(() => {
+		const hasSelected = filteredCategories.some(
+			(cat) => cat.id === selectedCategory,
+		);
+		if (!hasSelected) setSelectedCategory(0);
+	}, [filteredCategories, selectedCategory]);
+
+	const handleAmountChange = (text: string) => {
+		const numeric = text.replace(/[^0-9.,]/g, '');
+		const dotted = numeric.replace(',', '.');
+		const parts = dotted.split('.');
+		if (parts.length === 1) {
+			setAmount(parts[0]);
+		} else {
+			const integer = parts[0];
+			const decimal = parts.slice(1).join('').slice(0, 2);
+			setAmount(`${integer}.${decimal}`);
+		}
+	};
+
+	const isDisabled =
+		saving ||
+		!name.trim() ||
+		!amount ||
+		Number.parseFloat(amount) <= 0 ||
+		!date;
+
+	const handleConfirm = async () => {
+		const numAmount = Number.parseFloat(amount);
+		if (isDisabled || Number.isNaN(numAmount)) return;
+
+		setSaving(true);
+		try {
+			const existing = occurrence.realTransaction as
+				| Persisted<RealTransaction>
+				| undefined;
+			if (existing != null) {
+				await updateRealTransaction(existing, {
+					...existing,
+					name: name.trim(),
+					amount: numAmount,
+					date,
+					categoryId: selectedCategory,
+				});
+			} else {
+				await addRealTransaction({
+					accountId: DEFAULT_ACCOUNT_ID,
+					name: name.trim(),
+					amount: numAmount,
+					date,
+					type: occurrence.type,
+					categoryId: selectedCategory,
+					plannedTransactionId:
+						occurrence.plannedTransaction?.id ?? null,
+				});
+			}
+			onConfirmed();
+		} catch (e) {
+			console.error('Failed to confirm planned transaction:', e);
+			setFeedbackMessage(t('Failed to save changes'));
+		} finally {
+			setSaving(false);
+		}
+	};
+
+	const isEdit = occurrence.realTransaction != null;
+
+	return (
+		<View style={styles.container}>
+			<YStack backgroundColor="$background" style={styles.card}>
+				<XStack
+					justifyContent="space-between"
+					alignItems="center"
+					marginBottom={8}
+				>
+					<SizableText color="$primary100" size="$title2">
+						{isEdit
+							? t('Edit confirmed transaction')
+							: t('Confirm budgeted transaction')}
+					</SizableText>
+				</XStack>
+
+				{/* Budgeted amount reference */}
+				<SizableText color="$gray700" size="$2" marginBottom={8}>
+					{t('Budgeted amount line', { amount: occurrence.amount })}
+				</SizableText>
+
+				{feedbackMessage && (
+					<SizableText color="$caution" size="$2" marginBottom={8}>
+						{feedbackMessage}
+					</SizableText>
+				)}
+
+				<ScrollView style={styles.scrollContainer}>
+					<YStack gap={20} paddingVertical={20}>
+						{/* Name */}
+						<YStack gap={8}>
+							<SizableText color="$primary100" size="$title3">
+								{t('Name')}
+							</SizableText>
+							<Input
+								color="$primary100"
+								value={name}
+								onChangeText={setName}
+								placeholder={t('Enter transaction name')}
+								height={40}
+								borderRadius={6}
+								px="10px"
+								fontSize="$title3"
+								focusStyle={{ outlineColor: 'transparent' }}
+							/>
+						</YStack>
+
+						{/* Amount */}
+						<YStack gap={8}>
+							<SizableText color="$primary100" size="$title3">
+								{t('Amount')}
+							</SizableText>
+							<Input
+								color="$primary100"
+								value={amount}
+								onChangeText={handleAmountChange}
+								keyboardType="decimal-pad"
+								placeholder={t('Enter amount (€)')}
+								height={40}
+								borderRadius={6}
+								px="10px"
+								fontSize="$title3"
+								focusStyle={{ outlineColor: 'transparent' }}
+							/>
+						</YStack>
+
+						{/* Date */}
+						<YStack gap={8}>
+							<SizableText color="$primary100" size="$title3">
+								{t('Date')}
+							</SizableText>
+							<MultiPlatformDatePicker
+								value={date}
+								color="primary100"
+								onChange={setDate}
+							/>
+						</YStack>
+
+						{/* Category */}
+						{filteredCategories.length > 0 && (
+							<YStack gap={8}>
+								<SizableText color="$primary100" size="$title3">
+									{t('Category')}
+								</SizableText>
+								<XStack flexWrap="wrap">
+									{filteredCategories.map(
+										({ id, name: label }) => (
+											<Button
+												key={id}
+												onPress={() =>
+													setSelectedCategory(id)
+												}
+												size={28}
+												padding={14}
+												marginRight={8}
+												marginBottom={8}
+												backgroundColor={
+													id === selectedCategory
+														? '$primary200'
+														: '$white'
+												}
+											>
+												<SizableText size="$title3">
+													{label}
+												</SizableText>
+											</Button>
+										),
+									)}
+								</XStack>
+							</YStack>
+						)}
+					</YStack>
+				</ScrollView>
+
+				<XStack justifyContent="space-between" marginTop={20}>
+					<Button
+						borderRadius={28}
+						backgroundColor="$caution"
+						style={styles.button}
+						onPress={onClose}
+					>
+						<SizableText color="$primary100" size="$title3">
+							{t('Cancel')}
+						</SizableText>
+					</Button>
+					<Button
+						borderRadius={28}
+						backgroundColor={
+							isDisabled ? '$primary300' : '$primary200'
+						}
+						style={styles.button}
+						onPress={() => {
+							void handleConfirm();
+						}}
+						disabled={isDisabled}
+					>
+						<SizableText color="$white" size="$title3">
+							{isEdit ? t('Save') : t('Confirm')}
+						</SizableText>
+					</Button>
+				</XStack>
+			</YStack>
+		</View>
+	);
+};
+
+const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+		justifyContent: 'center',
+		alignItems: 'center',
+		backgroundColor: 'rgba(0, 0, 0, 0.4)',
+	},
+	card: {
+		width: '90%',
+		maxHeight: '80%',
+		padding: 20,
+		borderRadius: 16,
+		borderWidth: 2,
+		borderColor: '$black',
+	},
+	scrollContainer: {
+		flexGrow: 1,
+	},
+	button: {
+		width: '45%',
+		height: 50,
+	},
+});
+
+export default PlannedTransactionConfirmModal;

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -308,12 +308,14 @@ i18next
 				'Add income short': 'Lisää tulo',
 				'Add expense short': 'Lisää meno',
 				'Confirm planned transaction': 'Vahvista suunniteltu tapahtuma',
+				'Confirm budgeted transaction': 'Vahvista suunniteltu tapahtuma',
 				'Edit confirmed transaction': 'Muokkaa vahvistettua tapahtumaa',
 				'Fill details in next view.':
 					'Täytä tapahtuman tiedot seuraavassa näkymässä.',
 				'Select planned transaction to adjust':
 					'Valitse suunniteltu tapahtuma korjattavaksi',
 				'Planned amount line': 'Suunniteltu: {{amount}} €',
+				'Budgeted amount line': 'Suunniteltu: {{amount}} €',
 				'Corrected real amount line': 'Korjattu toteuma: {{amount}} €',
 				'No upcoming planned transactions.':
 					'Ei tulevia suunniteltuja tapahtumia.',

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -73,6 +73,12 @@ i18next
 				'Expense short': 'Expense',
 				'Record new income': 'Add new income',
 				'Record new expense': 'Add new expense',
+				'Add income short': 'Add income',
+				'Add expense short': 'Add expense',
+				'Confirm budgeted transaction': 'Confirm budgeted transaction',
+				'Edit confirmed transaction': 'Edit confirmed transaction',
+				'Confirm': 'Confirm',
+				'Failed to save changes': 'Failed to save changes',
 				'Fill details in next view.':
 					'Fill in the transaction details in the next view.',
 				'Select budgeted transaction to adjust':
@@ -299,6 +305,11 @@ i18next
 				'Expense short': 'meno',
 				'Record new income': 'Kirjaa uusi tulo',
 				'Record new expense': 'Kirjaa uusi meno',
+				'Add income short': 'Lisää tulo',
+				'Add expense short': 'Lisää meno',
+				'Confirm budgeted transaction': 'Vahvista budjetoitu tapahtuma',
+				'Edit confirmed transaction': 'Muokkaa vahvistettua tapahtumaa',
+				'Failed to save changes': 'Tallentaminen epäonnistui',
 				'Fill details in next view.':
 					'Täytä tapahtuman tiedot seuraavassa näkymässä.',
 				'Select budgeted transaction to adjust':

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -95,6 +95,7 @@ i18next
 				'Save adjustment': 'Save adjustment',
 				'Adjustment saved': 'Adjustment saved',
 				'Already confirmed': 'Already confirmed',
+				'Planned section title': 'Planned',
 				'Uncategorized default': 'Uncategorized',
 
 				//ADD NEW ITEM POPUP
@@ -324,8 +325,8 @@ i18next
 				'Save adjustment': 'Tallenna korjaus',
 				'Adjustment saved': 'Korjaus tallennettu',
 				'Already confirmed': 'Jo kirjatut',
+				'Planned section title': 'Suunnitellut',
 				'Uncategorized default': 'muu',
-				'Budgeted badge': 'suunniteltu',
 				
 				//ADD NEW ITEM POPUP
 				'Add a new item': 'Lisää uusi tapahtuma',

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -325,6 +325,7 @@ i18next
 				'Adjustment saved': 'Korjaus tallennettu',
 				'Already confirmed': 'Jo kirjatut',
 				'Uncategorized default': 'muu',
+				'Budgeted badge': 'suunniteltu',
 				
 				//ADD NEW ITEM POPUP
 				'Add a new item': 'Lisää uusi tapahtuma',

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -179,7 +179,6 @@ i18next
 				'Transaction deleted': 'Transaction deleted',
 				'Failed to delete transaction': 'Failed to delete transaction',
 				'Changes saved': 'Changes saved',
-				'Failed to save changes': 'Failed to save changes',
 
 				// ERROR
 				'Something went wrong': 'Something went wrong',
@@ -307,21 +306,20 @@ i18next
 				'Record new expense': 'Kirjaa uusi meno',
 				'Add income short': 'Lisää tulo',
 				'Add expense short': 'Lisää meno',
-				'Confirm budgeted transaction': 'Vahvista budjetoitu tapahtuma',
+				'Confirm planned transaction': 'Vahvista suunniteltu tapahtuma',
 				'Edit confirmed transaction': 'Muokkaa vahvistettua tapahtumaa',
-				'Failed to save changes': 'Tallentaminen epäonnistui',
 				'Fill details in next view.':
 					'Täytä tapahtuman tiedot seuraavassa näkymässä.',
-				'Select budgeted transaction to adjust':
-					'Valitse budjetoitu tapahtuma korjattavaksi',
-				'Budgeted amount line': 'Budjetoitu: {{amount}} €',
+				'Select planned transaction to adjust':
+					'Valitse suunniteltu tapahtuma korjattavaksi',
+				'Planned amount line': 'Suunniteltu: {{amount}} €',
 				'Corrected real amount line': 'Korjattu toteuma: {{amount}} €',
-				'No upcoming budgeted transactions.':
-					'Ei tulevia budjetoituja tapahtumia.',
-				'Adjusting budgeted amount line':
-					'Korjattava budjetoitu summa: {{amount}} €',
-				'Select budgeted transaction first':
-					'Valitse ensin budjetoitu tapahtuma',
+				'No upcoming planned transactions.':
+					'Ei tulevia suunniteltuja tapahtumia.',
+				'Adjusting planned amount line':
+					'Korjattava suunniteltu summa: {{amount}} €',
+				'Select planned transaction first':
+					'Valitse ensin suunniteltu tapahtuma',
 				'Corrected actual amount (€)': 'Korjattu toteuma (€)',
 				'Save adjustment': 'Tallenna korjaus',
 				'Adjustment saved': 'Korjaus tallennettu',


### PR DESCRIPTION
- Remove routes to add transactions page (home page & funds page)
- Adding transaction income/expense now opens a modal instead of the transaction page
- Planned transactions can now be edited/confirmed from the funds page
- Add a title to planned transactions to visually separate the transactions in the daily view
- Add some missing translations