### PR TITLE
Fix/usable funds timeframe adding extra day

### DIFF
--- a/src/store/useTimeframeStore.ts
+++ b/src/store/useTimeframeStore.ts
@@ -21,7 +21,7 @@ const addLength = (date: Date, timeframe: TimeframeLength) => {
 	let endDate = date;
 	switch (timeframe.type) {
 		case 'days':
-			endDate = addDays(date, timeframe.length - 1);
+			endDate = addDays(date, timeframe.length);
 			break;
 		case 'weeks':
 			endDate = addDays(date, timeframe.length * 7);

--- a/src/store/useTimeframeStore.ts
+++ b/src/store/useTimeframeStore.ts
@@ -20,7 +20,8 @@ interface TimeframeState {
 const addLength = (date: Date, timeframe: TimeframeLength) => {
 	switch (timeframe.type) {
 		case 'days':
-			return addDays(date, timeframe.length);
+			if (timeframe.length === 1) return date;
+			else return addDays(date, timeframe.length - 1);
 		case 'weeks':
 			return addDays(date, timeframe.length * 7);
 		case 'months':
@@ -68,6 +69,14 @@ export const useTimeframeStore = create<TimeframeState>()(
 					timeframeStartDay,
 					timeframeLength,
 				} = get();
+
+				// skip calculations if timeframe is 1 day
+				if (
+					timeframeLength.type === 'days' &&
+					timeframeLength.length === 1
+				) {
+					return date;
+				}
 
 				let currentTimeframeStart = new Date(
 					timeframeStartYear,

--- a/src/store/useTimeframeStore.ts
+++ b/src/store/useTimeframeStore.ts
@@ -18,17 +18,24 @@ interface TimeframeState {
 }
 
 const addLength = (date: Date, timeframe: TimeframeLength) => {
+	let endDate = date;
 	switch (timeframe.type) {
 		case 'days':
-			if (timeframe.length === 1) return date;
-			else return addDays(date, timeframe.length - 1);
+			endDate = addDays(date, timeframe.length - 1);
+			break;
 		case 'weeks':
-			return addDays(date, timeframe.length * 7);
+			endDate = addDays(date, timeframe.length * 7);
+			break;
 		case 'months':
-			return addMonths(date, timeframe.length);
+			endDate = addMonths(date, timeframe.length);
+			break;
 		case 'years':
-			return addYears(date, timeframe.length);
+			endDate = addYears(date, timeframe.length);
 	}
+	// remove next timeframes first day from current timeframe
+	endDate = addDays(endDate, -1);
+
+	return endDate;
 };
 
 /**
@@ -88,8 +95,9 @@ export const useTimeframeStore = create<TimeframeState>()(
 					timeframeLength,
 				);
 
-				while (date > currentTimeframeEnd) {
-					currentTimeframeStart = currentTimeframeEnd;
+				while (date > addDays(currentTimeframeEnd, 1)) {
+					// increment next timeframe start to current end + 1 for new start
+					currentTimeframeStart = addDays(currentTimeframeEnd, 1);
 					currentTimeframeEnd = addLength(
 						currentTimeframeStart,
 						timeframeLength,


### PR DESCRIPTION
Closes #162 

Huomasin tässä kans et jakson loppupäivä oli aina 1 päivä liian myöhään ja vikana päivänä näytettiin sit kans jo seuraavaa jaksoa. Nyt jakson pitäis näyttää esim kuukauden pituisen jakson silleen et alkaa esim 1.4. ja loppuu 30.4. ja seuraava sit alkaa 1.5.